### PR TITLE
Add UserId to authentication response and update roles

### DIFF
--- a/TomsFurnitureBackend/Controllers/AuthController.cs
+++ b/TomsFurnitureBackend/Controllers/AuthController.cs
@@ -71,6 +71,7 @@ namespace TomsFurnitureBackend.Controllers
                 return Ok(new
                 {
                     result.IsAuthenticated,
+                    result.UserId, // Bổ sung trả về userId
                     result.UserName,
                     result.Email,
                     result.Role,
@@ -323,7 +324,7 @@ namespace TomsFurnitureBackend.Controllers
         /// Retrieves a user by ID (admin only).
         /// </summary>
         [HttpGet("users/{id}")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,User")]
         public async Task<IActionResult> GetUserById(int id)
         {
             try
@@ -505,7 +506,7 @@ namespace TomsFurnitureBackend.Controllers
         /// Updates an existing user (admin only).
         /// </summary>
         [HttpPut("users/update/{id}")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,User")]
         public async Task<IActionResult> UpdateUser(int id, [FromBody] UpdateUserVModel model)
         {
             try

--- a/TomsFurnitureBackend/Services/AuthService.cs
+++ b/TomsFurnitureBackend/Services/AuthService.cs
@@ -301,6 +301,7 @@ namespace TomsFurnitureBackend.Services
                 return new AuthStatusVModel
                 {
                     IsAuthenticated = true,
+                    UserId = dbUser.Id, // Trả về userId
                     UserName = dbUser.UserName,
                     Email = dbUser.Email,
                     Role = dbUser.Role.RoleName

--- a/TomsFurnitureBackend/VModels/AuthVModel.cs
+++ b/TomsFurnitureBackend/VModels/AuthVModel.cs
@@ -4,6 +4,7 @@
     public class AuthStatusVModel
     {
         public bool IsAuthenticated { get; set; }
+        public int? UserId { get; set; } // Thêm userId
         public string? UserName { get; set; }
         public string? Email { get; set; }
         public string? Role { get; set; }


### PR DESCRIPTION
The authentication response now includes the UserId field for better client-side identification. Also, 'GetUserById' and 'UpdateUser' endpoints now allow both Admin and User roles instead of Admin only.